### PR TITLE
Remove the upper version limit on QA dependency

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -69,7 +69,7 @@ SUMMARY
   spec.add_dependency 'posix-spawn'
   spec.add_dependency 'power_converter', '~> 0.1', '>= 0.1.2'
   spec.add_dependency 'pul_uv_rails', '~> 2.0'
-  spec.add_dependency 'qa', '>= 2', '< 4' # questioning_authority
+  spec.add_dependency 'qa', '>= 2' # questioning_authority
   spec.add_dependency 'rails_autolink', '~> 1.1'
   spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer
   spec.add_dependency 'redis-namespace', '~> 1.5'


### PR DESCRIPTION
So that DONUT can pull in the Geonames HTTPS fix